### PR TITLE
SC-12764 Fix travis CI build to use Ubuntu 22 & JDK17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
+language: java
 sudo: required
- 
+
+dist: jammy
+
+jdk: openjdk17
+
 addons:
   sonarcloud:
     organization: "sonarcloud"
@@ -8,14 +13,14 @@ addons:
 
 env:
   - NODE_VERSION=16
-  
+
 script:
   - nvm install $NODE_VERSION
   - sonar-scanner
 
 cache:
   directories:
-    - '$HOME/.sonar/cache'
+    - "$HOME/.sonar/cache"
 
 # Don't copy the following part if you are using this project as a starting point of yours
 notifications:


### PR DESCRIPTION
The build is currently broken because java 11 is used to scan this project.

This PR bumps the distribution used in CI from `xenial` to `jammy` (which includes JDK17, and switches java version to it).