### PR TITLE
BUILD-6088 Fix bad link in SECURITY.md file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,4 +10,4 @@ For security vulnerabilities found in third-party libraries, please also contact
 
 ## Responsible Disclosure Policy
 
-For more information about disclosing a security vulnerability to Sonar, please refer to our community post: [Responsible Vulnerability Disclosure](https://community.sonarsource.com/t/responsible-vulnerability-disclosure/9317/6).
+For more information about disclosing a security vulnerability to Sonar, please refer to our community post: [Responsible Vulnerability Disclosure](https://community.sonarsource.com/t/responsible-vulnerability-disclosure/9317).


### PR DESCRIPTION
This file needs to be present for all Sonar public repositories, for more information please refer to BUILD-6088.